### PR TITLE
Include functionality to install the mysql client

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,3 +47,13 @@ fedora_admin_password: nimdAarodef!
 
 # Defines the URL to access the fedora server
 fedora_server_fqdn: "fedora.library.ucla.edu"
+
+# MySQL packages
+mysql_defaultrepo_version: "80"
+mysql_yumrepo_rpm: "https://dev.mysql.com/get/mysql{{ mysql_defaultrepo_version }}-community-release-el7-1.noarch.rpm"
+mysql_install_version: "5.6"
+mysql_installrepo_version: "{{ mysql_install_version.split('.')[0] }}{{ mysql_install_version.split('.')[1] }}"
+mysql_packages:
+  - mysql-community-client
+  - mysql-community-devel
+  - mysql-community-libs

--- a/tasks/install_mysql_packages.yml
+++ b/tasks/install_mysql_packages.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Install MySQL Packages
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ mysql_packages }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,3 +93,9 @@
     name: fedora
     state: started
     enabled: yes
+
+- name: Set-up MySQL yum repository
+  include_tasks: setup_mysql_yumrepo.yml
+
+- name: Install MySQL packages
+  include_tasks: install_mysql_packages.yml

--- a/tasks/setup_mysql_yumrepo.yml
+++ b/tasks/setup_mysql_yumrepo.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Install MySQL yum repository
+  yum:
+    name: "{{ mysql_yumrepo_rpm }}"
+    state: present
+
+- name: Disable default MySQL repository
+  command: >
+    yum-config-manager --disable mysql{{ mysql_defaultrepo_version }}-community
+  when: mysql_defaultrepo_version != mysql_installrepo_version
+
+- name: Enable version-specific MySQL repository
+  command: >
+    yum-config-manager --enable mysql{{ mysql_installrepo_version }}-community
+  when: mysql_defaultrepo_version != mysql_installrepo_version


### PR DESCRIPTION
I'm including the mysql client on the fedora server to ensure we can access the fedora database for the purpose of back-ups and repository refreshes. 